### PR TITLE
Badge Fixes

### DIFF
--- a/src/transformer/events/core/badge_awarded.php
+++ b/src/transformer/events/core/badge_awarded.php
@@ -58,14 +58,14 @@ function badge_awarded(array $config, \stdClass $event) {
     $awarder = $manual ? (utils\get_user($config, $repo->read_record_by_id('user', $manual->issuerid))) : 'System';
     $badgetype = [1 => "Global", 2 => "Course"][$badge->type];
 
-    
+
     $statement = [[
         'actor' => $actor,
         'verb' => [
             'id' => 'https://w3id.org/xapi/tla/verbs/achieved',
-                   'display' => [
-                       'en' => 'Achieved'
-                   ]],
+            'display' => [
+                'en' => 'Achieved'
+            ]],
         'object' => [
             'id' =>  $config['app_url'].'/badges/overview.php?id='.$event->objectid,
             'objectType' => 'Activity',
@@ -75,7 +75,7 @@ function badge_awarded(array $config, \stdClass $event) {
                 'type' => 'https://xapi.edlm/profiles/edlm-lms/concepts/activity-types/badge',
                 'extensions' => [
                     'https://xapi.edlm/profiles/edlm-lms/v1/concepts/activity-extensions/badge-type' =>  $badgetype,
-                    'https://xapi.edlm/profiles/edlm-lms/v1/concepts/activity-extensions/badge-version' => $badge->version                             
+                    'https://xapi.edlm/profiles/edlm-lms/v1/concepts/activity-extensions/badge-version' => $badge->version
                 ]
             ],
         ],
@@ -86,7 +86,7 @@ function badge_awarded(array $config, \stdClass $event) {
             'language' => $lang,
             'instructor' => $awarder,
             'contextActivities' =>  [
-                'category' => [
+                'category' => [[
                     'id' => $config['app_url'],
                     'objectType' => 'Activity',
                     'definition' => [
@@ -95,13 +95,13 @@ function badge_awarded(array $config, \stdClass $event) {
                         ],
                         'type' => 'http://id.tincanapi.com/activitytype/lms'
                     ]
-                ],
+                ]],
             ],
             'extensions' => array_merge(utils\extensions\base($config, $event, $course),[
                 'https://xapi.edlm/profiles/edlm-lms/v1/concepts/context-extensions/badge-assignment-method' => ($manual ? 'Manual' : 'Automatic')])
         ]]];
     if ($course){
-        $statement[0]['context']['contextActivities']['parent'] = [
+        $statement[0]['context']['contextActivities']['parent'] = [[
             'id' => $config['app_url'].'/course/view.php?id='.$course->id,
             'objectType' => 'Activity',
             'definition' => [
@@ -109,8 +109,8 @@ function badge_awarded(array $config, \stdClass $event) {
                 'description' => [$lang => $course->summary],
                 'type' => 'https://w3id.org/xapi/cmi5/activitytype/course'
             ]
-        ];
+        ]];
     }
-    
+
     return $statement;
 }

--- a/tests/core/badge_awarded/user_achieved_badge/statements.json
+++ b/tests/core/badge_awarded/user_achieved_badge/statements.json
@@ -1,77 +1,85 @@
 [
-    {
-	"actor": {
-	    "name": "test_recipient_firstname test_recipient_lastname",
-	    "account": {
-		"homePage": "http://www.example.org",
-		"name": "1"
-	    }
-	},
-	"verb": {
-	    "id": "https://w3id.org/xapi/tla/verbs/achieved",
-	    "display": {
-		"en": "Achieved"
-	    }
-	},
-	"object": {
-	    "id": "http://www.example.org/badges/overview.php?id=1",
-	    "objectType": "Activity",
-	    "definition": {
-		"name": {"en":"test_badgename"},
-		"description": {"en": "test badge description"},
-		"type": "https://xapi.edlm/profiles/edlm-lms/concepts/activity-types/badge",
-		"extensions": {
-		    "https://xapi.edlm/profiles/edlm-lms/v1/concepts/activity-extensions/badge-type": "Course",
-		    "https://xapi.edlm/profiles/edlm-lms/v1/concepts/activity-extensions/badge-version": "1.0"
-		}
-	    }
-	},
-	"result":{
-	    "response":"you got the test badge!"
-	},
-	"context": {
-	    "language": "en",
-	    "instructor": {
-		"name": "test_awarder_firstname test_awarder_lastname",
-		"account": {
-		    "homePage": "http://www.example.org",
-		    "name": "2"
-		}
-	    },
-	    "contextActivities": {
-		"category": {
-		    "id": "http://www.example.org",
-		    "objectType": "Activity",
-		    "definition": {
-			"name": {
-			    "en": "EDLM Moodle LMS"
-			},
-			"type": "http://id.tincanapi.com/activitytype/lms"
-		    }
-		},
-		"parent": {
-		    "id": "http://www.example.org/course/view.php?id=1",
-		    "objectType": "Activity",
-		    "definition": {
-			"name": {
-			    "en": "test_course_name"
-			},
-			"description": {
-			    "en": "test_course_summary"
-			},
-			"type": "https://w3id.org/xapi/cmi5/activitytype/course"
-		    }
-		}
-	    },
-	    "extensions": {
-		"https://xapi.edlm/profiles/edlm-lms/v1/concepts/context-extensions/badge-assignment-method": "Manual",
-		"http://lrs.learninglocker.net/define/extensions/info": {
-		    "http://moodle.org": "1.0.0",
-		    "https://github.com/xAPI-vle/moodle-logstore_xapi": "0.0.0-development",
-		    "event_name": "\\core\\event\\badge_awarded",
-		    "event_function": "\\src\\transformer\\events\\core\\badge_awarded"
-		}
-	    }
-	}
+  {
+    "actor": {
+      "name": "test_recipient_firstname test_recipient_lastname",
+      "account": {
+        "homePage": "http://www.example.org",
+        "name": "1"
+      }
+    },
+    "verb": {
+      "id": "https://w3id.org/xapi/tla/verbs/achieved",
+      "display": {
+        "en": "Achieved"
+      }
+    },
+    "object": {
+      "id": "http://www.example.org/badges/overview.php?id=1",
+      "objectType": "Activity",
+      "definition": {
+        "name": {
+          "en": "test_badgename"
+        },
+        "description": {
+          "en": "test badge description"
+        },
+        "type": "https://xapi.edlm/profiles/edlm-lms/concepts/activity-types/badge",
+        "extensions": {
+          "https://xapi.edlm/profiles/edlm-lms/v1/concepts/activity-extensions/badge-type": "Course",
+          "https://xapi.edlm/profiles/edlm-lms/v1/concepts/activity-extensions/badge-version": "1.0"
+        }
+      }
+    },
+    "result": {
+      "response": "you got the test badge!"
+    },
+    "context": {
+      "language": "en",
+      "instructor": {
+        "name": "test_awarder_firstname test_awarder_lastname",
+        "account": {
+          "homePage": "http://www.example.org",
+          "name": "2"
+        }
+      },
+      "contextActivities": {
+        "category": [
+          {
+            "id": "http://www.example.org",
+            "objectType": "Activity",
+            "definition": {
+              "name": {
+                "en": "EDLM Moodle LMS"
+              },
+              "type": "http://id.tincanapi.com/activitytype/lms"
+            }
+          }
+        ],
+        "parent": [
+          {
+            "id": "http://www.example.org/course/view.php?id=1",
+            "objectType": "Activity",
+            "definition": {
+              "name": {
+                "en": "test_course_name"
+              },
+              "description": {
+                "en": "test_course_summary"
+              },
+              "type": "https://w3id.org/xapi/cmi5/activitytype/course"
+            }
+          }
+        ]
+      },
+      "extensions": {
+        "https://xapi.edlm/profiles/edlm-lms/v1/concepts/context-extensions/badge-assignment-method": "Manual",
+        "http://lrs.learninglocker.net/define/extensions/info": {
+          "http://moodle.org": "1.0.0",
+          "https://github.com/xAPI-vle/moodle-logstore_xapi": "0.0.0-development",
+          "event_name": "\\core\\event\\badge_awarded",
+          "event_function": "\\src\\transformer\\events\\core\\badge_awarded"
+        }
+      }
     }
+  }
 ]

--- a/tests/core/badge_revoked/user_forfeited_badge/data.json
+++ b/tests/core/badge_revoked/user_forfeited_badge/data.json
@@ -1,30 +1,29 @@
 {
-    "user":[
-	{
-	    "id": 1,
-	    "firstname": "test_revoker_firstname",
-	    "lastname": "test_revoker_lastname",
-	    "email": "revoker@test.com",
-	    "username": "revoker"
-	},
-	{
-	    "id": 2,
-	    "firstname": "test_recipient_firstname",
-	    "lastname": "test_recipient_lastname",
-	    "email": "recipient@test.com",
-	    "username": "recipient"
-	}
-
-    ],
-    "badge":[
-	{
-	    "id": 1,
-	    "name": "test_badgename",
-	    "description": "test badge description",
-	    "type": 1,
-	    "courseid": null,
-	    "version": "1.0",
-	    "message": "you got the test badge!"
-	}
-    ]
+  "user": [
+    {
+      "id": 1,
+      "firstname": "test_revoker_firstname",
+      "lastname": "test_revoker_lastname",
+      "email": "revoker@test.com",
+      "username": "revoker"
+    },
+    {
+      "id": 2,
+      "firstname": "test_recipient_firstname",
+      "lastname": "test_recipient_lastname",
+      "email": "recipient@test.com",
+      "username": "recipient"
+    }
+  ],
+  "badge": [
+    {
+      "id": 1,
+      "name": "test_badgename",
+      "description": "test badge description",
+      "type": 1,
+      "courseid": null,
+      "version": "1.0",
+      "message": "you got the test badge!"
+    }
+  ]
 }

--- a/tests/core/badge_revoked/user_forfeited_badge/event.json
+++ b/tests/core/badge_revoked/user_forfeited_badge/event.json
@@ -1,9 +1,9 @@
 {
-    "id":1,
-    "eventname":"\\core\\event\\badge_revoked",
-    "relateduserid":2,
-    "timecreated": 1433946701,
-    "objectid":1,
-    "userid":1,
-    "objecttable": "badge"
+  "id": 1,
+  "eventname": "\\core\\event\\badge_revoked",
+  "relateduserid": 2,
+  "timecreated": 1433946701,
+  "objectid": 1,
+  "userid": 1,
+  "objecttable": "badge"
 }

--- a/tests/core/badge_revoked/user_forfeited_badge/statements.json
+++ b/tests/core/badge_revoked/user_forfeited_badge/statements.json
@@ -1,60 +1,67 @@
 [
-    {
-	"actor":{
-	    "name": "test_recipient_firstname test_recipient_lastname",
-	    "account": {
-		"homePage": "http://www.example.org",
-		"name": "2"
-	    }
-	},
-	"verb": {
-	    "id": "https://w3id.org/xapi/tla/verbs/forfeited",
-	    "display": {
-		"en": "Forfeited"
-	    }
-	},
-	"object":{
-	    "id": "http://www.example.org/badges/overview.php?id=1",
-	    "objectType":"Activity",
-	    "definition":{
-		"name": {
-		    "en":"test_badgename"
-		},
-		"description":{"en":"test badge description"},
-		"type": "https://xapi.edlm/profiles/edlm-lms/concepts/activity-types/badge",
-		"extensions":{
-		    "https://xapi.edlm/profiles/edlm-lms/v1/concepts/activity-extensions/badge-type":"Global",
-                    "https://xapi.edlm/profiles/edlm-lms/v1/concepts/activity-extensions/badge-version" : "1.0"
-		}
-	    }
-	},
-	"context":{"language":"en",
-		   "instructor":{
-		       "name":"test_revoker_firstname test_revoker_lastname",
-		       "account":{
-			   "homePage":"http://www.example.org",
-			   "name":"1"
-		       }
-		   },
-		   "contextActivities":{
-		       "category":{
-			   "id":"http://www.example.org",
-			   "objectType":"Activity",
-			   "definition":{
-			       "name":{"en":"EDLM Moodle LMS"},
-			       "type":"http://id.tincanapi.com/activitytype/lms"
-			   }
-		       }
-		   },
-		   "extensions":{
- "https://xapi.edlm/profiles/edlm-lms/v1/concepts/context-extensions/badge-assignment-method": "Manual",
-		       "http://lrs.learninglocker.net/define/extensions/info": {
-			   "http://moodle.org": "1.0.0",
-			   "https://github.com/xAPI-vle/moodle-logstore_xapi": "0.0.0-development",
-			   "event_name": "\\core\\event\\badge_revoked",
-			   "event_function": "\\src\\transformer\\events\\core\\badge_revoked"
-		       }
-		   }
-		  }
+  {
+    "actor": {
+      "name": "test_recipient_firstname test_recipient_lastname",
+      "account": {
+        "homePage": "http://www.example.org",
+        "name": "2"
+      }
+    },
+    "verb": {
+      "id": "https://w3id.org/xapi/tla/verbs/forfeited",
+      "display": {
+        "en": "Forfeited"
+      }
+    },
+    "object": {
+      "id": "http://www.example.org/badges/overview.php?id=1",
+      "objectType": "Activity",
+      "definition": {
+        "name": {
+          "en": "test_badgename"
+        },
+        "description": {
+          "en": "test badge description"
+        },
+        "type": "https://xapi.edlm/profiles/edlm-lms/concepts/activity-types/badge",
+        "extensions": {
+          "https://xapi.edlm/profiles/edlm-lms/v1/concepts/activity-extensions/badge-type": "Global",
+          "https://xapi.edlm/profiles/edlm-lms/v1/concepts/activity-extensions/badge-version": "1.0"
+        }
+      }
+    },
+    "context": {
+      "language": "en",
+      "instructor": {
+        "name": "test_revoker_firstname test_revoker_lastname",
+        "account": {
+          "homePage": "http://www.example.org",
+          "name": "1"
+        }
+      },
+      "contextActivities": {
+        "category": [
+          {
+            "id": "http://www.example.org",
+            "objectType": "Activity",
+            "definition": {
+              "name": {
+                "en": "EDLM Moodle LMS"
+              },
+              "type": "http://id.tincanapi.com/activitytype/lms"
+            }
+          }
+        ]
+      },
+      "extensions": {
+        "https://xapi.edlm/profiles/edlm-lms/v1/concepts/context-extensions/badge-assignment-method": "Manual",
+        "http://lrs.learninglocker.net/define/extensions/info": {
+          "http://moodle.org": "1.0.0",
+          "https://github.com/xAPI-vle/moodle-logstore_xapi": "0.0.0-development",
+          "event_name": "\\core\\event\\badge_revoked",
+          "event_function": "\\src\\transformer\\events\\core\\badge_revoked"
+        }
+      }
     }
+  }
 ]


### PR DESCRIPTION
I missed on review that badge statements were not valid xAPI. This corrects the error by wrapping contextActivities in Arrays.
Also added the optional course to revocation statements, we want it in either case.