### PR TITLE
Remove CI workaround

### DIFF
--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -71,8 +71,6 @@ jobs:
 
       - name: Install the plugin.
         run: |
-          # Install nvm v0.39.7 (temp workaround for issue #309).
-          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
           moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
         env:
           DB: ${{ matrix.database }}


### PR DESCRIPTION
An old workaround was installing NVM + Node twice, no longer needed and speeds up CI a little