### PR TITLE
remove bad formatting directives for json

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,11 @@ indent_style = space
 indent_size = 2
 charset = utf-8
 
-[*.{php,json}]
+[*.{json}]
+indent_size = 2
+tab_width = 2
+trim_trailing_whitespace=true
+
+[*.{php}]
 indent_size = 4
 trim_trailing_whitespace=true


### PR DESCRIPTION
this was forcing some bad formatting for json, lumping it in with the PHP. This changes the config so it doesn't conflict with pretty-printing.