### PR TITLE
Ci workaround

### DIFF
--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -31,8 +31,8 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.2']
-        moodle-branch: ['MOODLE_401_STABLE', 'MOODLE_402_STABLE']
-        database: [pgsql, mariadb]
+        moodle-branch: ['MOODLE_402_STABLE'] # 'MOODLE_401_STABLE' # currently off due to workaround
+        database: [pgsql] # mariadb # our plugin is DB-agnostic so we only do pgsql for now
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1']
+        php: ['8.2']
         moodle-branch: ['MOODLE_401_STABLE', 'MOODLE_402_STABLE']
         database: [pgsql, mariadb]
 


### PR DESCRIPTION
This gets CI working again until we know what's up with this: https://github.com/shivammathur/setup-php/issues/874

Note that we are now only testing moodle 402 and pgsql, with PHP 8.2. This leads to a TON of deprecation warnings on unit tests but they do work.