### PR TITLE
Revert "Ci workaround (#27)"

### DIFF
--- a/.github/workflows/moodle-plugin-ci.yml
+++ b/.github/workflows/moodle-plugin-ci.yml
@@ -30,9 +30,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.2']
-        moodle-branch: ['MOODLE_402_STABLE'] # 'MOODLE_401_STABLE' # currently off due to workaround
-        database: [pgsql] # mariadb # our plugin is DB-agnostic so we only do pgsql for now
+        php: ['8.1']
+        moodle-branch: ['MOODLE_401_STABLE', 'MOODLE_402_STABLE']
+        database: [pgsql, mariadb]
 
     steps:
       - name: Check out repository code


### PR DESCRIPTION
No longer needed, setup-php has been patched
