### PR TITLE
Correct Type in Calendar Sub tests

### DIFF
--- a/tests/core/calendar_subscription_created/user_created_calendar_subscription/statements.json
+++ b/tests/core/calendar_subscription_created/user_created_calendar_subscription/statements.json
@@ -3,7 +3,7 @@
     "actor": {
       "account": {
         "homePage": "http://www.example.org",
-        "name": 1
+        "name": "1"
       },
       "name": "test_fullname"
     },

--- a/tests/core/calendar_subscription_deleted/user_deleted_calendar_subscription/statements.json
+++ b/tests/core/calendar_subscription_deleted/user_deleted_calendar_subscription/statements.json
@@ -3,7 +3,7 @@
     "actor": {
       "account": {
         "homePage": "http://www.example.org",
-        "name": 1
+        "name": "1"
       },
       "name": "test_fullname"
     },


### PR DESCRIPTION
Other tooling detected an incorrect type in the expected xAPI statements, this just corrects that. No functional impact.