### PR TITLE
remove trailing spaces on scorm serialized event data

### DIFF
--- a/tests/mod_scorm/scoreraw_submitted/existing_scoreraw_submitted/event.json
+++ b/tests/mod_scorm/scoreraw_submitted/existing_scoreraw_submitted/event.json
@@ -5,6 +5,6 @@
   "timecreated": 1433946701,
   "objectid": 1,
   "eventname": "\\mod_scorm\\event\\scoreraw_submitted",
-  "other": "a:2:{s:8:\"cmivalue\";i:100;s:9:\"attemptid\";i:1;} ",
+  "other": "a:2:{s:8:\"cmivalue\";i:100;s:9:\"attemptid\";i:1;}",
   "contextinstanceid": 1
 }

--- a/tests/mod_scorm/status_submitted/existing_status_submitted/event.json
+++ b/tests/mod_scorm/status_submitted/existing_status_submitted/event.json
@@ -5,6 +5,6 @@
   "timecreated": 1433946701,
   "objectid": 1,
   "eventname": "\\mod_scorm\\event\\status_submitted",
-  "other": "a:1:{s:9:\"attemptid\";i:1;} ",
+  "other": "a:1:{s:9:\"attemptid\";i:1;}",
   "contextinstanceid": 1
 }


### PR DESCRIPTION
remove trailing spaces on scorm serialized event data